### PR TITLE
createrepo_mod: support also non-module repositories

### DIFF
--- a/createrepo_mod/README.md
+++ b/createrepo_mod/README.md
@@ -8,6 +8,10 @@ have the modularity support implemented in `createrepo_c` itself. See
 
 https://bugzilla.redhat.com/show_bug.cgi?id=1816753
 
+This tool can be used as a drop-in replacement for `createrepo_c` with
+one caveat. You need to specify `<directory>` before `[options]`.
+Otherwise it works fine with both module and non-module repositories.
+
 Please see the official Fedora Modularity documentation for the reference of how
 module repositories should be created
 

--- a/createrepo_mod/createrepo_mod.py
+++ b/createrepo_mod/createrepo_mod.py
@@ -96,6 +96,8 @@ def main():
     parser = get_arg_parser()
     args, _ = parser.parse_known_args()
     yamls = find_module_yamls(args.path)
+    if not yamls:
+        return
     dump_modules_yaml(args.path, yamls)
     run_modifyrepo(args.path, "gz")
 


### PR DESCRIPTION
The point is to make it easier for build systems, which now doesn't have
to decide what kind of repository they are creating and instead just
call `createrepo_mod` in all cases. Also, once `createrepo_c` itself
supports modules, the migration will be trivial.