### PR TITLE
Loosen the python3-libmodulemd dependency to just libmodulemd

### DIFF
--- a/modulemd-tools.spec
+++ b/modulemd-tools.spec
@@ -8,18 +8,20 @@ BuildArch: noarch
 URL: https://github.com/rpm-software-management/modulemd-tools
 Source0: https://github.com/rpm-software-management/modulemd-tools/archive/%{version}/%{name}-%{version}.tar.gz
 
+BuildRequires: libmodulemd >= 2
 BuildRequires: python3-devel
 BuildRequires: python3-click
 BuildRequires: python3-dnf
-BuildRequires: python3-libmodulemd
 BuildRequires: python3-hawkey
 BuildRequires: python3-createrepo_c
+BuildRequires: python3-gobject
 
+Requires: libmodulemd >= 2
 Requires: python3-click
 Requires: python3-dnf
-Requires: python3-libmodulemd
 Requires: python3-hawkey
 Requires: python3-createrepo_c
+Requires: python3-gobject
 
 
 %description


### PR DESCRIPTION
There is no `python3-libmodulemd` package for EPEL8, it is
a part of the `libmodulemd` package. For Fedora, we have both
options. So let's not if-else the spec and just install `libmodulemd`
everywhere and presume, that the python library will be available.