### PR TITLE
Require createrepo_c for the createrepo_mod package

### DIFF
--- a/modulemd-tools.spec
+++ b/modulemd-tools.spec
@@ -9,6 +9,7 @@ URL: https://github.com/rpm-software-management/modulemd-tools
 Source0: https://github.com/rpm-software-management/modulemd-tools/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: libmodulemd >= 2
+BuildRequires: createrepo_c
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python3-click
@@ -18,6 +19,7 @@ BuildRequires: python3-createrepo_c
 BuildRequires: python3-gobject
 
 Requires: libmodulemd >= 2
+Requires: createrepo_c
 Requires: python3-click
 Requires: python3-dnf
 Requires: python3-hawkey


### PR DESCRIPTION
The `createrepo_mod` tool internally uses both `createrepo_c` and
`modifyrepo_c` tools, we need them as dependencies.