### PR TITLE
Fix PEP8 in all tools

### DIFF
--- a/createrepo_mod/createrepo_mod.py
+++ b/createrepo_mod/createrepo_mod.py
@@ -24,7 +24,7 @@ from distutils.version import LooseVersion
 
 import gi
 gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
+from gi.repository import Modulemd  # noqa: E402
 
 
 def run_createrepo(args):

--- a/dir2module/dir2module.py
+++ b/dir2module/dir2module.py
@@ -17,7 +17,7 @@ from dnf.subject import Subject
 
 
 gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
+from gi.repository import Modulemd  # noqa: E402
 
 
 class Module(object):
@@ -125,11 +125,11 @@ class Package(object):
     def _get_header(self):
         """
         Examine a RPM package file and return its header
-        See https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch16s04.html
+        See docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch16s04.html
         """
         ts = rpm.TransactionSet()
         ts.setKeyring(rpm.keyring())
-        ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES|rpm._RPMVSF_NODIGESTS)
+        ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES | rpm._RPMVSF_NODIGESTS)
         with open(self.path, "r") as f:
             hdr = ts.hdrFromFdno(f.fileno())
             return hdr
@@ -218,7 +218,6 @@ def main():
         path = os.path.expanduser(args.pkglist)
         packages = find_packages_in_file(path)
 
-
     packages = [Package(package) for package in packages]
     licenses = {package.license for package in packages}
     nevras = {package.nevra for package in packages}
@@ -237,7 +236,7 @@ def main():
 
     if missing_labels and not args.force:
         raise RuntimeError("All packages need to contain the `modularitylabel` header. "
-                       "To suppress this constraint, use `--force` parameter")
+                           "To suppress this constraint, use `--force` parameter")
 
     module = Module(name, stream, version, context, arch, args.summary,
                     description, args.license, licenses, nevras, requires)
@@ -247,7 +246,6 @@ def main():
     else:
         module.dump()
         print("Created {0}".format(module.filename))
-
 
 
 if __name__ == "__main__":

--- a/modulemd-generate-macros/modulemd-generate-macros.py
+++ b/modulemd-generate-macros/modulemd-generate-macros.py
@@ -19,10 +19,6 @@ import subprocess
 import argparse
 from modulemd_tools.yaml import _yaml2stream, load
 
-import gi
-gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
-
 
 log = logging.getLogger("MBS")
 
@@ -264,7 +260,6 @@ def main():
         print("{0}\n".format(str(ex)))
         print("Please review {}/module-build-macros.spec".format(td))
         sys.exit(1)
-
 
 
 if __name__ == "__main__":

--- a/modulemd-merge/modulemd-merge.py
+++ b/modulemd-merge/modulemd-merge.py
@@ -16,7 +16,8 @@ import createrepo_c as cr
 
 import gi
 gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
+from gi.repository import Modulemd  # noqa: E402
+
 
 def hande_repomd(args, merger, repomd_filename):
     try:
@@ -51,11 +52,13 @@ def hande_repomd(args, merger, repomd_filename):
     logging.debug("{fn}: modules section found in repomd.xml, but href file {href} does not exist".
                   format(fn=repomd_filename, href=filename))
     if not args.ignore_no_input:
-        raise ValueError("{fn}: modules section found in repomd.xml, but href file {href} does not exist".
-                         format(fn=repomd_filename, href=filename))
+        raise ValueError("{fn}: modules section found in repomd.xml, but href file {href} does "
+                         "not exist".format(fn=repomd_filename, href=filename))
     return False
 
-# check type and existence of input file, directly or indirectly calls merge_file when a yaml is found
+
+# check type and existence of input file, directly or indirectly calls merge_file
+# when a yaml is found
 def merge_input(args, merger, filename):
     if os.path.isdir(filename):
         logging.debug("{}: is a directory".format(filename))
@@ -66,7 +69,8 @@ def merge_input(args, merger, filename):
         else:
             logging.debug("{}: no repomd.xml in or below directory".format(filename))
             if not args.ignore_no_input:
-                raise ValueError('{fn} is a directory, but no repomd.xml file existing in or below'.format(fn=filename))
+                raise ValueError('{fn} is a directory, but no repomd.xml file existing in or below'
+                                 .format(fn=filename))
 
     elif os.path.isfile(filename):
         logging.debug("{}: is a regular file".format(filename))
@@ -81,6 +85,7 @@ def merge_input(args, merger, filename):
         if not args.ignore_no_input:
             raise ValueError('input file {fn} does not exist'.format(fn=filename))
 
+
 def merge_file(merger, filename):
     logging.debug("{}: Loading YAML".format(filename))
 
@@ -94,14 +99,16 @@ def merge_file(merger, filename):
 
     modnames = index.get_module_names()
     defstreams = index.get_default_streams()
-    logging.info("{}: Found {} modulemds and {} modulemd-defaults".format(filename, len(modnames), len(defstreams)))
+    logging.info("{}: Found {} modulemds and {} modulemd-defaults".format(filename, len(modnames),
+                 len(defstreams)))
 
     merger.associate_index(index, 0)
 
+
 def get_arg_parser():
     description = "Merge several modules.yaml files (rpm modularity metadata) into one."
-    parser = argparse.ArgumentParser("modulemd-merge",
-                                     description=description, formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser("modulemd-merge", description=description,
+                                     formatter_class=argparse.RawTextHelpFormatter)
 
     # flag options
     parser.add_argument("-v", "--verbose", help="increase output verbosity",
@@ -114,9 +121,11 @@ def get_arg_parser():
     # positional arguments
     parser.add_argument("input", nargs="+", help="input filename(s) or directories.\n"
                         "repomd.xml files are parsed and modules hrefs contained are merged.\n"
-                        "If a directory is given, it is searched for repodata/repomd.xml and repomd.xml")
+                        "If a directory is given, it is searched for repodata/repomd.xml\n"
+                        "and repomd.xml")
     parser.add_argument("output", help="YAML output filename")
     return parser
+
 
 def parse_args():
     parser = get_arg_parser()
@@ -128,6 +137,7 @@ def parse_args():
         logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
     return args
+
 
 def main():
     args = parse_args()
@@ -141,7 +151,8 @@ def main():
 
     modnames = merged_index.get_module_names()
     defstreams = merged_index.get_default_streams()
-    logging.info("merged result: {} modulemds and {} modulemd-defaults".format(len(modnames), len(defstreams)))
+    logging.info("merged result: {} modulemds and {} modulemd-defaults".format(len(modnames),
+                                                                               len(defstreams)))
 
     logging.debug("Writing YAML to {}".format(args.output))
     with open(args.output, 'w') as output:
@@ -151,6 +162,7 @@ def main():
             output.write("")
         else:
             output.write(merged_index.dump_to_string())
+
 
 if __name__ == "__main__":
     try:

--- a/modulemd_tools/modulemd_tools/yaml.py
+++ b/modulemd_tools/modulemd_tools/yaml.py
@@ -7,8 +7,9 @@ and all transformation functions are `str` -> `str`.
 import os
 import gi
 import yaml
+
 gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
+from gi.repository import Modulemd  # noqa: E402
 
 
 def is_valid(mod_yaml):
@@ -66,7 +67,8 @@ def update(mod_yaml, name=None, stream=None, version=None, context=None,
     value is used instead.
 
     For the official documentation of the modulemd YAML format and it's values,
-    please see https://github.com/fedora-modularity/libmodulemd/blob/main/yaml_specs/modulemd_stream_v2.yaml
+    please see
+    https://github.com/fedora-modularity/libmodulemd/blob/main/yaml_specs/modulemd_stream_v2.yaml
     It will allow you to better understand the parameters of this function.
 
     Args:
@@ -223,7 +225,7 @@ def upgrade(mod_yaml, version):
     Downgrades aren't supported even in case where it would be possible.
     """
     parsed = yaml.safe_load(mod_yaml or "")
-    if not parsed or not "version" in parsed:
+    if not parsed or "version" not in parsed:
         raise ValueError("Missing modulemd version")
 
     supported = [1, 2]

--- a/modulemd_tools/tests/test_yaml.py
+++ b/modulemd_tools/tests/test_yaml.py
@@ -9,7 +9,7 @@ from modulemd_tools.yaml import (is_valid, validate, create, update, dump,
 
 import gi
 gi.require_version("Modulemd", "2.0")
-from gi.repository import Modulemd
+from gi.repository import Modulemd  # noqa: E402
 
 
 def old_libmodulemd():
@@ -392,7 +392,7 @@ class TestYaml(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             _stream2yaml(mod_stream)
         self.assertIn("Could not validate stream to emit: Summary is missing",
-                       str(context.exception))
+                      str(context.exception))
 
 
 yaml1 = """---


### PR DESCRIPTION
Let's do this before writing tests for the tools, so I can enable flake8 exit status checks in tox #24 and we can see _full_ picture of the code in Travis.