### PR TITLE
Drop dependency on python3-gobject

### DIFF
--- a/modulemd-tools.spec
+++ b/modulemd-tools.spec
@@ -12,7 +12,6 @@ BuildRequires: createrepo_c
 BuildRequires: argparse-manpage
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
-BuildRequires: python3-gobject
 BuildRequires: python3-libmodulemd >= 2.9.3
 BuildRequires: python3-click
 %if ! 0%{?rhel}
@@ -30,7 +29,6 @@ Requires: python3-dnf
 Requires: python3-hawkey
 Requires: python3-createrepo_c
 Requires: python3-pyyaml
-Requires: python3-gobject
 Requires: python3-libmodulemd >= 2.9.3
 
 


### PR DESCRIPTION
This was added as a temporary workaround when python3-libmodulemd
wasn't available in EPEL 8 (see PR#16 for more information) and so we
temporarily depended on libmodulemd and python3-gobject packages. As
@sgallagher pointed out, it is redundant now.