### PR TITLE
modulemd_tools: drop python3-parameterized dependency

### DIFF
--- a/modulemd-tools.spec
+++ b/modulemd-tools.spec
@@ -19,7 +19,6 @@ BuildRequires: python3-dnf
 BuildRequires: python3-hawkey
 BuildRequires: python3-createrepo_c
 BuildRequires: python3-pyyaml
-BuildRequires: python3-parameterized
 BuildRequires: python3-pytest
 
 Requires: createrepo_c

--- a/modulemd_tools/tests/test_yaml.py
+++ b/modulemd_tools/tests/test_yaml.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 from unittest import mock
-from parameterized import parameterized
 import yaml
 from distutils.version import LooseVersion
 from modulemd_tools.yaml import (is_valid, validate, create, update, dump,
@@ -327,11 +326,11 @@ class TestYaml(unittest.TestCase):
         self.assertIn("Cannot downgrade modulemd version",
                       str(context.exception))
 
-    @parameterized.expand([[None], [""], ["foo: bar"]])
-    def test_upgrade_empty_yaml(self, mod_yaml):
-        with self.assertRaises(ValueError) as context:
-            upgrade(mod_yaml, 2)
-        self.assertIn("Missing modulemd version", str(context.exception))
+    def test_upgrade_empty_yaml(self):
+        for mod_yaml in [None, "", "foo: bar"]:
+            with self.assertRaises(ValueError) as context:
+                upgrade(mod_yaml, 2)
+            self.assertIn("Missing modulemd version", str(context.exception))
 
     def test_upgrade_unexpected_version(self):
         # Neither current modulemd version cannot be unexpected


### PR DESCRIPTION
It's not worth depending on it since we use it for just one simple
test.