### PR TITLE
bld2repo: do not create empty repos when --result-dir is used

### DIFF
--- a/bld2repo/bld2repo/cli.py
+++ b/bld2repo/bld2repo/cli.py
@@ -48,7 +48,7 @@ def main():
 
     pkgs, rpm_num = add_rpm_urls(pkgs, config)
 
-    rpm_bulk_download(pkgs, rpm_num, config.arch)
+    rpm_bulk_download(pkgs, rpm_num, config.result_dir)
 
     create_repo(config.result_dir)
 


### PR DESCRIPTION
Without this change, RPMs were downloaded to a directory (`x86_64` by default) in the current working directory.  `createrepo` then created an empty repo in the specified directory because the downloaded RPMs were not there.