### PR TITLE
bld2repo: print name of the file being downloaded

### DIFF
--- a/modulemd_tools/bld2repo/__init__.py
+++ b/modulemd_tools/bld2repo/__init__.py
@@ -99,17 +99,17 @@ def rpm_bulk_download(pkgs, rpm_num, working_dir):
     :param int rpm_num: number of all the rpms included in pkgs
     :param str working_dir: the dir where the rpms will be downloaded
     """
-    print("Starting bulk download of rpms...")
+    print("Starting bulk download of {total} rpms...".format(total=rpm_num))
     rpm_dwnlded = 0
 
     for pkg in pkgs:
         for url in pkg["rpm_urls"]:
-            # we print the status of the download
-            status = "[{done}/{total}]".format(done=rpm_dwnlded, total=rpm_num)
-            print(status, end="\r", flush=True)
-            # we store the rpm in a similar location as it is on the storage server
             url_parts = url.split("/")
             filename = url_parts[-1]
+            # print the status of the download
+            status = "\x1b[2K\r[{done}/{total}] {file}".format(done=rpm_dwnlded, total=rpm_num, file=filename)
+            print(status, end='', flush=True)
+            # store the rpm in a similar location as it is on the storage server
             arch = url_parts[-2]
             pkg_name = "-".join([url_parts[-5], url_parts[-4], url_parts[-3]])
             target_pkg_dir = "/".join([working_dir, pkg_name, arch])
@@ -125,10 +125,7 @@ def rpm_bulk_download(pkgs, rpm_num, working_dir):
             download_file(url, target_pkg_dir, filename)
             rpm_dwnlded += 1
 
-    # update the status last time to mark all of the rpms downloaded
-    status = "[{done}/{total}]".format(done=rpm_dwnlded, total=rpm_num)
-    print(status)
-    print("Download successful.")
+    print("\x1b[2K\rDownload successful.")
 
 
 def create_repo(working_dir):


### PR DESCRIPTION
... so that the output captured by Covscan does not look like this:
```
>>> 2022-03-10 13:18:47	"bld2repo" "--build-id" "1736248" "--result-dir" "/tmp/csmocktt6b6pz6/local-build-repo" "--koji-host" "https://brewhub.engineering.redhat.com/brewhub" "--koji-storage-host" "http://download.devel.redhat.com/brewroot"
Retriewing build metadata from:  https://brewhub.engineering.redhat.com/brewhub
Build with the ID 1736248 found.
Found the build tag ' module-libreoffice-flatpak-9000020210920115144-4a735dea-build ' associated with the build.
Gathering packages and rpms tagged in ' module-libreoffice-flatpak-9000020210920115144-4a735dea-build '.
Gathering done.
Starting bulk download of rpms...
[0/1202]
[1/1202]
[2/1202]
[3/1202]
[4/1202]
[5/1202]
[6/1202]
[7/1202]
[8/1202]
[9/1202]
[10/1202]
[11/1202]
[12/1202]
[13/1202]
[14/1202]
[15/1202]
[16/1202]

[...]

[1198/1202]
[1199/1202]
[1200/1202]
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/bld2repo/__init__.py", line 90, in download_file
    urllib.request.urlretrieve(url, abs_file_path)
  File "/usr/lib64/python3.6/urllib/request.py", line 248, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib64/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib64/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib64/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.6/urllib/request.py", line 564, in error
    result = self._call_chain(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 756, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/lib64/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib64/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 502: Proxy Error

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/bld2repo", line 11, in <module>
    load_entry_point('bld2repo==0.1', 'console_scripts', 'bld2repo')()
  File "/usr/lib/python3.6/site-packages/bld2repo/cli.py", line 51, in main
    rpm_bulk_download(pkgs, rpm_num, config.result_dir)
  File "/usr/lib/python3.6/site-packages/bld2repo/__init__.py", line 127, in rpm_bulk_download
    download_file(url, target_pkg_dir, filename)
  File "/usr/lib/python3.6/site-packages/bld2repo/__init__.py", line 93, in download_file
    url=ex.url, msg=ex.msg, code=ex.code))
Exception: HTTP error for url: http://download.eng.brq.redhat.com/brewroot/vol/rhel-8/packages/flatpak-rpm-macros/34/1.module+el9alpha+11633+a924cde5/x86_64/flatpak-rpm-macros-34-1.module+el9alpha+11633+a924cde5.x86_64.rpm
Error message: Proxy Error
HTTP code: 502
```