### PR TITLE
modulemd_add_platform: Don't crash on a document without a module name and with a default profile

### DIFF
--- a/modulemd_tools/modulemd_add_platform/modulemd_add_platform.py
+++ b/modulemd_tools/modulemd_add_platform/modulemd_add_platform.py
@@ -284,9 +284,15 @@ def equaled_modulemd_packager(a, b):
 
     Return true if equaled. False otherwise. It modifies the documents.
     """
-    # convert_to_index() requires mandatory fields (e.g. summary) to be set.
-    # It seems that validation in packager_read_*() has a bug.
+    # convert_to_index() requires some mandatory fields to be set.
     for document in a, b:
+        # Automatic-mandatory fields (name, stream) are requrired for
+        # modulemd-defaults document derived from a default profile.
+        document.set_module_name('dummy')
+        document.set_stream_name('dummy')
+        # Also other mandatory fields (e.g. summary) needs to be set.
+        # It seems that validation in packager_read_*() has a bug not catching
+        # it.
         document.set_summary('dummy')
         document.set_description('dummy')
     return a.convert_to_index().dump_to_string() \

--- a/tests/test_modulemd_add_platform/test_use.py
+++ b/tests/test_modulemd_add_platform/test_use.py
@@ -282,3 +282,36 @@ def test_positive_nested_fields_inside_a_context():
     error, output = process_string(logger, input, False, 'A', 'B')
     assert(error == 0)
     assert(output == expected)
+
+
+def test_positive_default_profile_without_module_name():
+    input = """
+    document: modulemd-packager
+    version: 3
+    data:
+        configurations:
+            - context: 'A'
+              platform: A
+        profiles:
+            foo:
+                default: true
+                rpms:
+    """
+    expected = """
+    document: modulemd-packager
+    version: 3
+    data:
+        configurations:
+            - context: 'A'
+              platform: A
+            - context: 'B'
+              platform: B
+        profiles:
+            foo:
+                default: true
+                rpms:
+    """
+
+    error, output = process_string(logger, input, False, 'A', 'B')
+    assert(error == 0)
+    assert(output == expected)


### PR DESCRIPTION
convert_to_index() called for comparing serialized indices segfaults
if a modulemd-packager-v3 document has no module name, but it has
a profile marked as default. libmodulemd then attempts to generate
a modulemd-default-v1 document which requires a module name. If the
name is not set, an assertion fails and the library terminates:

~~~~
    (process:41508): libmodulemd-CRITICAL **: 14:54:41.578: modulemd_defaults_set_module_name: assertion 'module_name' failed

    (process:41508): libmodulemd-CRITICAL **: 14:54:41.578: modulemd_defaults_v1_add_default_profile_for_stream: assertion 'stream_name' failed
    Neoprávněný přístup do paměti (SIGSEGV) (core dumped [obraz paměti uložen])
~~~~

For some reason the crash does not occur without a stream name. Though
it should (libmodulemd-2.14.0). According to libmodulemd
documentation, an error instead of crash should be returned.

Nevertheless, modulemd_add_platform needs to adjust not to trigger the
error (once libmodulemd is fixed), the the crash (now).