### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+---
+name: Pull request checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, unlocked, edited]
+
+jobs:
+  run-linter:
+    uses: ./.github/workflows/test.yml
+    with:
+      test_type: flake8
+  run-pytest:
+    uses: ./.github/workflows/test.yml
+    with:
+      test_type: py310
+  run-build:
+    needs: [run-linter, run-pytest]
+    uses: ./.github/workflows/rpm.yml

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,47 +1,34 @@
 ---
-name: RPM
+name: Create RPM
 
 on:
-  pull_request:
-    branches: [master]
   workflow_dispatch:
   workflow_call:
 
 jobs:
-  test:
-    uses: rpm-software-management/modulemd-tools/.github/workflows/test.yml@master
-
   rpm:
-    runs-on: self-hosted
-    concurrency: test-env
+    runs-on: ubuntu-latest
     environment: test-env
-    needs: test
+    env:
+      ARCH: ${{ github.runner_arch }}
+    container:
+      image: ghcr.io/mkulik-rh/modulemd_tools-ci:latest
     steps:
-      - uses: actions/checkout@v2
-      - name: (Pre) Clean up
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set env variables
         run: |
-          ARCH=$(uname -i)
-          git clean -dfx
-          mock --scrub all -r fedora-35-$ARCH
-      - name: Create source RPM within mock
+          echo "ARCH=$(uname -i)" >> $GITHUB_ENV
+          echo "VERSION=$(sed -n 's/Version: //p' modulemd-tools.spec | head -1)" >> $GITHUB_ENV
+      - name: Create sources
         run: |
-          ARCH=$(uname -i)
-          VERSION=$(sed -n 's/Version: //p' modulemd-tools.spec | head -1)
           git archive HEAD --prefix=modulemd-tools-$VERSION/ -o modulemd-tools-$VERSION.tar
           gzip modulemd-tools-$VERSION.tar
-          mock -v -r fedora-35-$ARCH --buildsrpm --spec modulemd-tools.spec --sources modulemd-tools-$VERSION.tar.gz
-          cp /var/lib/mock/fedora-35-$ARCH/result/modulemd-tools-$VERSION-*.src.rpm .
-      - name: Clean up
+      - name: Setup directory tree
         run: |
-          ARCH=$(uname -i)
-          mock --scrub all -r fedora-35-$ARCH
-      - name: Rebuild RPM within mock
+          rpmdev-setuptree
+      - name: Build SRPM & RPM
         run: |
-          ARCH=$(uname -i)
-          VERSION=$(sed -n 's/Version: //p' modulemd-tools.spec | head -1)
-          mock -v -r fedora-35-$ARCH --postinstall rebuild modulemd-tools-$VERSION-*.src.rpm
-      - name: (Post) Clean up
-        run: |
-          ARCH=$(uname -i)
-          git clean -dfx
-          mock --scrub all -r fedora-35-$ARCH
+          cp modulemd-tools-$VERSION.tar.gz $HOME/rpmbuild/SOURCES/
+          cp modulemd-tools.spec $HOME/rpmbuild/SPECS/
+          rpmbuild -ba $HOME/rpmbuild/SPECS/modulemd-tools.spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,39 @@
 ---
-name: Test
+name: Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      test_type:
+        type: choice
+        required: true
+        description: Select type of tests
+        options:
+          - flake8
+          - py310
   workflow_call:
+    inputs:
+      test_type:
+        required: true
+        type: string
 
 jobs:
   test:
-    runs-on: self-hosted
-    concurrency: test-env
+    name: tests
+    runs-on: ubuntu-latest
     environment: test-env
+    env:
+      SITEPACKAGES: true
+    container:
+      image: ghcr.io/mkulik-rh/modulemd_tools-ci:latest
     steps:
-      - uses: actions/checkout@v2
-      - name: (Pre) Clean up
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: ${{ github.event.inputs.test_type }}
+        if: "${{ github.event.inputs.test_type != '' }}"
         run: |
-          docker rmi -f modulemd-tools
-          git clean -dfx
-      - name: Run tests in F35 docker container
+          tox -vvv -e ${{ github.event.inputs.test_type }}
+      - name: ${{ inputs.test_type }}
+        if: "${{ inputs.test_type != '' }}"
         run: |
-          docker build -t modulemd-tools -f Dockerfile-tests .
-          docker run --rm -v $GITHUB_WORKSPACE:/modulemd-tools:Z modulemd-tools
-      - name: (Post) Clean up
-        run: |
-          docker rmi -f modulemd-tools
-          git clean -dfx
+          tox -vvv -e ${{ inputs.test_type }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:35
+FROM fedora:latest
 
 RUN dnf -y update && \
     dnf -y install dnf-plugins-core && \
     dnf -y builddep modulemd-tools && \
-    dnf -y install gcc krb5-devel python3-tox
+    dnf -y install git rpmdevtools gcc krb5-devel python3-tox
 
 CMD cd /modulemd-tools && ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -ex
-
-SITEPACKAGES=true tox -vvv -e py310,flake8
-rm -rf .tox/ build/ dist/ modulemd_tools.egg-info/
-find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete


### PR DESCRIPTION
This PR should fix all CI workflows. It also adds few additional ones.

Workflows use ubuntu-latest VM as runner. This is only Linux (VM) runner provided by MS. `-lastest` is probably not the best choice but `ubuntu-20.04` does not seems to work and if it does it takes few minutes to be picked up by VM.

**`GHCR_PAT` secret needs to be added for to the project before merge** It is generate token that is needed to access Github packages docker repository. It needs to be generated by **rpm-software-management** if it's not possible then we can use other account but small changes to the code needs to be made for that.

### Build Docker
This workflow automatically builds fedora docker image (latest official version, currently 35) with all packages needed by other workflows.

This workflow will run automatically:

- when changes to Docker file are made.
- once a month (to update image pkgs)
- it can also by started manually

We need to have space to store image somewhere so we use GitHub Packages for that.

### Pull request checks
This workflow defines reusable workflow which should be run on PR.

### Tests
This workflow run tests for a given branch. This is reusable workflow and it is used by PR. It uses docker container image build by _Build Docker_ workflow.

### Create RPM
This one will build SRPM & RPM. Previously used mock for this is replaced by rpmbuild since mock does not play nice with docker (needs special privileges). Current docker actions does not support extended privileges. mock can be used but instead action we would need to use bare docker commands or custom actions.

RPM build is only done for x86_64 since only this type of runner is provided by MS. Testing for ARM64 would require qemu.
