### PR TITLE
createrepo: replace deprecated LooseVersion

### DIFF
--- a/modulemd_tools/createrepo_mod/createrepo_mod.py
+++ b/modulemd_tools/createrepo_mod/createrepo_mod.py
@@ -16,11 +16,16 @@ https://docs.fedoraproject.org/en-US/modularity/hosting-modules/
 """
 
 
-import os
-import sys
-import subprocess
 import argparse
-from distutils.version import LooseVersion
+import os
+import subprocess
+import sys
+
+# python3-packaging in not available in RHEL 8.x
+try:
+    from packaging.version import Version
+except ModuleNotFoundError:
+    from distutils.version import LooseVersion as Version
 
 import gi
 gi.require_version("Modulemd", "2.0")
@@ -99,7 +104,7 @@ def createrepo_c_with_builtin_module_support():
     """
     cmd = ["rpm", "-q", "createrepo_c", "--queryformat", "%{VERSION}"]
     createrepo_c_version = subprocess.check_output(cmd).decode("utf-8")
-    return LooseVersion(createrepo_c_version) >= LooseVersion("0.16.1")
+    return Version(createrepo_c_version) >= Version("0.16.1")
 
 
 def main():

--- a/modulemd_tools/modulemd_tools/yaml.py
+++ b/modulemd_tools/modulemd_tools/yaml.py
@@ -7,7 +7,12 @@ and all transformation functions are `str` -> `str`.
 import os
 import gi
 import yaml
-from distutils.version import StrictVersion
+
+# python3-packaging in not available in RHEL 8.x
+try:
+    from packaging.version import Version
+except ModuleNotFoundError:
+    from distutils.version import StrictVersion as Version
 
 gi.require_version("Modulemd", "2.0")
 from gi.repository import Modulemd  # noqa: E402
@@ -312,7 +317,7 @@ def _modulemd_read_packager_string(mod_yaml, name=None, stream=None):
     Fedora but we still use old libmodulemd (2.9.4) on RHEL8, which doesn't
     provide its replacement in the form of `Modulemd.read_packager_string`.
     """
-    if StrictVersion(Modulemd.get_version()) < StrictVersion("2.11"):
+    if Version(Modulemd.get_version()) < Version("2.11"):
         mod_stream = Modulemd.ModuleStreamV2.new(name, stream)
         mod_stream = mod_stream.read_string(mod_yaml, True, name, stream)
         return mod_stream
@@ -327,7 +332,7 @@ def _modulestream_upgrade_ext(mod_stream, version):
     Fedora but we still use old libmodulemd (2.9.4) on RHEL8, which doesn't
     provide its replacement in the form of `Modulemd.ModuleStream.upgrade_ext`.
     """
-    if StrictVersion(Modulemd.get_version()) < StrictVersion("2.10"):
+    if Version(Modulemd.get_version()) < Version("2.10"):
         return mod_stream.upgrade(version)
 
     mod_upgraded = mod_stream.upgrade_ext(version)

--- a/tests/test_modulemd_tools/test_yaml.py
+++ b/tests/test_modulemd_tools/test_yaml.py
@@ -2,9 +2,14 @@ import os
 import unittest
 from unittest import mock
 import yaml
-from distutils.version import LooseVersion
 from modulemd_tools.modulemd_tools.yaml import (
     is_valid, validate, create, update, dump, upgrade, _yaml2stream, _stream2yaml)
+
+# python3-packaging in not available in RHEL 8.x
+try:
+    from packaging.version import Version
+except ModuleNotFoundError:
+    from distutils.version import LooseVersion as Version
 
 import gi
 gi.require_version("Modulemd", "2.0")
@@ -19,7 +24,7 @@ def old_libmodulemd():
     skip those few test on EPEL8 until it receives an update.
     See also `080e2bb`
     """
-    return LooseVersion(Modulemd.get_version()) < LooseVersion("2.11.1")
+    return Version(Modulemd.get_version()) < Version("2.11.1")
 
 
 class TestYaml(unittest.TestCase):


### PR DESCRIPTION
Warnings in pytest:

```
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12.
```