### PR TITLE
modulemd_merge: test using file instead of output stream

### DIFF
--- a/tests/test_modulemd_merge/conftest.py
+++ b/tests/test_modulemd_merge/conftest.py
@@ -1,6 +1,13 @@
+import tempfile
 from textwrap import dedent
 
 import pytest
+
+
+@pytest.fixture
+def tmp_file():
+    tmp = tempfile.NamedTemporaryFile()
+    return tmp.name
 
 
 @pytest.fixture

--- a/tests/test_modulemd_merge/test_modulemd_merge.py
+++ b/tests/test_modulemd_merge/test_modulemd_merge.py
@@ -24,19 +24,20 @@ def test_modulemd_merge_loading():
     assert modulemd_merge
 
 
-def test_modulemd_merge_two_yamls(capsys, two_modules_merged_yamls):
+def test_modulemd_merge_two_yamls(tmp_file, two_modules_merged_yamls):
 
     inputs = (os.path.join(test_data_dir, "moduleA.yaml"),
               os.path.join(test_data_dir, "moduleB.yaml"))
-    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs)):
+    kwargs = {"ignore_no_input": True, "output": tmp_file, "to_stdout": False}
+    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs, **kwargs)):
         modulemd_merge.main()
 
-    captured = capsys.readouterr()
-    assert [d for d in yaml.load_all(captured.out, Loader=yaml.SafeLoader)] == [
-        d for d in yaml.load_all(two_modules_merged_yamls, Loader=yaml.SafeLoader)]
+    with open(tmp_file, "r") as f:
+        assert [d for d in yaml.load_all(f, Loader=yaml.SafeLoader)] == [
+            d for d in yaml.load_all(two_modules_merged_yamls, Loader=yaml.SafeLoader)]
 
 
-def test_modulemd_merge_two_yamls_first_missing(capsys):
+def test_modulemd_merge_two_yamls_first_missing():
 
     inputs = (os.path.join(test_data_dir, "missing-file.yaml"),
               os.path.join(test_data_dir, "moduleB.yaml"))
@@ -47,38 +48,40 @@ def test_modulemd_merge_two_yamls_first_missing(capsys):
     assert f"input file {test_data_dir}/missing-file.yaml does not exist" in str(excinfo.value)
 
 
-def test_modulemd_merge_two_yamls_first_missing_ignore_no_input(capsys, moduleB_yaml):
+def test_modulemd_merge_two_yamls_first_missing_ignore_no_input(tmp_file, moduleB_yaml):
 
     inputs = (os.path.join(test_data_dir, "missing-file.yaml"),
               os.path.join(test_data_dir, "moduleB.yaml"))
-    kwargs = {"ignore_no_input": True}
+    kwargs = {"ignore_no_input": True, "output": tmp_file, "to_stdout": False}
     with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs, **kwargs)):
         modulemd_merge.main()
 
-    captured = capsys.readouterr()
-    assert [d for d in yaml.load_all(captured.out, Loader=yaml.SafeLoader)] == [
-        d for d in yaml.load_all(moduleB_yaml, Loader=yaml.SafeLoader)]
+    with open(tmp_file, "r") as f:
+        assert [d for d in yaml.load_all(f, Loader=yaml.SafeLoader)] == [
+            d for d in yaml.load_all(moduleB_yaml, Loader=yaml.SafeLoader)]
 
 
-def test_modulemd_merge_module_with_repodata_dir(capsys, module_with_repodata_dir):
+def test_modulemd_merge_module_with_repodata_dir(tmp_file, module_with_repodata_dir):
 
     inputs = (os.path.join(test_data_dir, "moduleA.yaml"),
               test_repodata_dir)
-    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs)):
+    kwargs = {"output": tmp_file, "to_stdout": False}
+    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs, **kwargs)):
         modulemd_merge.main()
 
-    captured = capsys.readouterr()
-    assert [d for d in yaml.load_all(captured.out, Loader=yaml.SafeLoader)] == [
-        d for d in yaml.load_all(module_with_repodata_dir, Loader=yaml.SafeLoader)]
+    with open(tmp_file, "r") as f:
+        assert [d for d in yaml.load_all(f, Loader=yaml.SafeLoader)] == [
+            d for d in yaml.load_all(module_with_repodata_dir, Loader=yaml.SafeLoader)]
 
 
-def test_modulemd_merge_module_with_repomd_file(capsys, module_with_repodata_dir):
+def test_modulemd_merge_module_with_repomd_file(tmp_file, module_with_repodata_dir):
 
     inputs = (os.path.join(test_data_dir, "moduleA.yaml"),
               test_repomd_file)
-    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs)):
+    kwargs = {"output": tmp_file, "to_stdout": False}
+    with patch("argparse.ArgumentParser.parse_args", return_value=_testrun_args(inputs, **kwargs)):
         modulemd_merge.main()
 
-    captured = capsys.readouterr()
-    assert [d for d in yaml.load_all(captured.out, Loader=yaml.SafeLoader)] == [
-        d for d in yaml.load_all(module_with_repodata_dir, Loader=yaml.SafeLoader)]
+    with open(tmp_file, "r") as f:
+        assert [d for d in yaml.load_all(f, Loader=yaml.SafeLoader)] == [
+            d for d in yaml.load_all(module_with_repodata_dir, Loader=yaml.SafeLoader)]


### PR DESCRIPTION
That fixes the issue where on some systems tests might fail. I'm not sure why it only happens on some systems. pytest version for failed/succeeded run is the same. Failed run can succeed by adding `-s` to pytest.

This behavior can be observed by running test for example in Centos Stream 8: `python3 -m pytest -vv`

Output snippet:
[output_test.txt](https://github.com/rpm-software-management/modulemd-tools/files/8550626/output_test.txt)

