### PR TITLE
repo2module: don't traceback because of a modular SRPM in the repo

### DIFF
--- a/modulemd_tools/repo2module/cli.py
+++ b/modulemd_tools/repo2module/cli.py
@@ -61,6 +61,11 @@ def get_source_packages(packages):
     """
     source_packages = set()
     for pkg in packages:
+        # In this case, the `pkg` is a SRPM file
+        if not pkg.rpm_sourcerpm:
+            source_packages.add(pkg.name)
+            continue
+
         # Get the source RPM NEVRA without the trailing ".rpm"
         subject = Subject(pkg.rpm_sourcerpm[:-4])
 


### PR DESCRIPTION
Fix RHBZ 2186223